### PR TITLE
Add custom mtm:dtbook-to-pef script that uses dotify:xml-to-pef directly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.daisy.pipeline.modules.braille</groupId>
     <artifactId>braille-modules-parent</artifactId>
-    <version>1.9.1</version>
+    <version>1.9.5-SNAPSHOT</version>
     <relativePath />
   </parent>
 
@@ -29,6 +29,9 @@
       <groupId>org.daisy.pipeline.modules.braille</groupId>
       <artifactId>dotify-core</artifactId>
     </dependency>
+    <!--
+        runtime dependencies
+    -->
     <dependency>
       <groupId>org.daisy.pipeline.modules.braille</groupId>
       <artifactId>css-utils</artifactId>
@@ -48,6 +51,14 @@
       <groupId>org.daisy.dotify</groupId>
       <artifactId>dotify.hyphenator.impl</artifactId>
       <scope>runtime</scope>
+    </dependency>
+    <!--
+        test dependencies
+    -->
+    <dependency>
+      <groupId>org.daisy.pipeline.modules.braille</groupId>
+      <artifactId>pef-utils</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.daisy.maven</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,11 @@
       <artifactId>dotify.hyphenator.impl</artifactId>
       <scope>runtime</scope>
     </dependency>
+    <dependency>
+      <groupId>org.daisy.dotify</groupId>
+      <artifactId>dotify.text.impl</artifactId>
+      <scope>runtime</scope>
+    </dependency>
     <!--
         test dependencies
     -->

--- a/src/main/resources/META-INF/catalog.xml
+++ b/src/main/resources/META-INF/catalog.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE catalog
   PUBLIC "-//OASIS/DTD Entity Resolution XML Catalog V1.0//EN" "http://www.oasis-open.org/committees/entity/release/1.0/catalog.dtd">
-<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
+<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog" xmlns:px="http://www.daisy.org/ns/pipeline">
+  <uri name="http://www.nlb.no/pipeline/modules/braille/dtbook-to-pef/dtbook-to-pef.xpl" uri="../xml/dtbook-to-pef.xpl" px:script="true"/>
   <nextCatalog catalog="org:daisy:pipeline:modules:braille:css-utils"/>
   <nextCatalog catalog="org:daisy:pipeline:modules:braille:dotify-utils"/>
   <nextCatalog catalog="org:daisy:dotify:translator:impl"/>

--- a/src/main/resources/xml/dtbook-to-pef.xpl
+++ b/src/main/resources/xml/dtbook-to-pef.xpl
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<p:declare-step type="mtm:dtbook-to-pef" version="1.0"
+                xmlns:mtm="http://www.mtm.se/pipeline/"
+                xmlns:p="http://www.w3.org/ns/xproc"
+                xmlns:px="http://www.daisy.org/ns/pipeline/xproc"
+                xmlns:dotify="http://code.google.com/p/dotify/"
+                xmlns:pef="http://www.daisy.org/ns/2008/pef"
+                exclude-inline-prefixes="#all"
+                name="main">
+    
+    <p:input port="source" primary="true" px:name="source" px:media-type="application/x-dtbook+xml"/>
+    
+    <p:option name="include-preview" required="false" px:type="boolean" select="''"/>
+    <p:option name="include-brf" required="false" px:type="boolean" select="''"/>
+    <p:option name="output-dir" required="true" px:output="result" px:type="anyDirURI"/>
+    
+    <p:import href="http://www.daisy.org/pipeline/modules/braille/dotify-utils/library.xpl"/>
+    <p:import href="http://www.daisy.org/pipeline/modules/braille/pef-utils/library.xpl"/>
+    
+    <dotify:xml-to-obfl locale="sv-SE" dotify-options="(rows:29)(cols:28)(rowgap:4)"/>
+    
+    <dotify:obfl-to-pef locale="sv-SE" mode="uncontracted"/>
+    
+    <pef:store>
+        <p:with-option name="output-dir" select="$output-dir"/>
+        <p:with-option name="name" select="replace(p:base-uri(/),'^.*/([^/]*)\.[^/\.]*$','$1')">
+            <p:pipe step="main" port="source"/>
+        </p:with-option>
+        <p:with-option name="include-preview" select="$include-preview"/>
+        <p:with-option name="include-brf" select="$include-brf"/>
+    </pef:store>
+    
+</p:declare-step>

--- a/src/test/java/MTMTest.java
+++ b/src/test/java/MTMTest.java
@@ -5,15 +5,20 @@ import java.io.FilenameFilter;
 
 import org.daisy.maven.xproc.xprocspec.XProcSpecRunner;
 
+import org.daisy.pipeline.braille.dotify.DotifyTranslator;
+
 import static org.daisy.pipeline.pax.exam.Options.brailleModule;
+import static org.daisy.pipeline.pax.exam.Options.calabashConfigFile;
 import static org.daisy.pipeline.pax.exam.Options.domTraversalPackage;
 import static org.daisy.pipeline.pax.exam.Options.felixDeclarativeServices;
 import static org.daisy.pipeline.pax.exam.Options.forThisPlatform;
 import static org.daisy.pipeline.pax.exam.Options.logbackBundles;
 import static org.daisy.pipeline.pax.exam.Options.logbackConfigFile;
+import static org.daisy.pipeline.pax.exam.Options.pipelineModule;
 import static org.daisy.pipeline.pax.exam.Options.thisBundle;
 import static org.daisy.pipeline.pax.exam.Options.xprocspecBundles;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -32,7 +37,17 @@ import static org.ops4j.pax.exam.CoreOptions.options;
 
 @RunWith(PaxExam.class)
 @ExamReactorStrategy(PerClass.class)
-public class TranslationTest {
+public class MTMTest {
+	
+	@Inject
+	private DotifyTranslator.Provider provider;
+	
+	@Test
+	public void testTranslation() {
+		DotifyTranslator translator = provider.get("(locale:sv_SE)").iterator().next();
+		assertEquals("⠠⠙⠑⠞⠀⠜⠗⠀⠥⠝⠙⠑⠗⠀⠍⠕⠗⠛⠕⠝⠍⠪⠞⠑⠞⠀⠙⠑⠞⠀⠓⠜⠝⠙⠑⠗⠄⠀⠠⠍⠁⠗⠊⠁⠀⠓⠡⠇⠇⠑⠗⠀⠚⠥⠎⠞⠀⠏⠡⠀⠁⠞⠞⠀⠇⠜⠎⠁⠀⠥⠏⠏⠀⠑⠝⠀⠗⠁⠏⠏⠕⠗⠞⠄",
+		             translator.transform("Det är under morgonmötet det händer. Maria håller just på att läsa upp en rapport."));
+	}
 	
 	@Inject
 	private XProcSpecRunner xprocspecRunner;
@@ -53,6 +68,7 @@ public class TranslationTest {
 		return options(
 			logbackConfigFile(),
 			logbackBundles(),
+			calabashConfigFile(),
 			domTraversalPackage(),
 			felixDeclarativeServices(),
 			mavenBundle().groupId("com.google.guava").artifactId("guava").versionAsInProject(),
@@ -61,10 +77,17 @@ public class TranslationTest {
 			mavenBundle().groupId("org.daisy.braille").artifactId("braille-css").versionAsInProject(),
 			mavenBundle().groupId("org.apache.servicemix.bundles").artifactId("org.apache.servicemix.bundles.antlr-runtime").versionAsInProject(),
 			mavenBundle().groupId("com.googlecode.texhyphj").artifactId("texhyphj").versionAsInProject(),
+			mavenBundle().groupId("org.daisy.braille").artifactId("braille-utils.api").versionAsInProject(),
+			mavenBundle().groupId("org.daisy.braille").artifactId("braille-utils.pef-tools").versionAsInProject(),
+			mavenBundle().groupId("org.daisy.braille").artifactId("braille-utils.impl").versionAsInProject(),
+			mavenBundle().groupId("org.daisy.libs").artifactId("jing").versionAsInProject(),
 			mavenBundle().groupId("org.daisy.dotify").artifactId("dotify.api").versionAsInProject(),
 			mavenBundle().groupId("org.daisy.dotify").artifactId("dotify.common").versionAsInProject(),
 			mavenBundle().groupId("org.daisy.dotify").artifactId("dotify.translator.impl").versionAsInProject(),
 			mavenBundle().groupId("org.daisy.dotify").artifactId("dotify.hyphenator.impl").versionAsInProject(),
+			mavenBundle().groupId("org.daisy.dotify").artifactId("dotify.formatter.impl").versionAsInProject(),
+			mavenBundle().groupId("org.daisy.dotify").artifactId("dotify.task-api").versionAsInProject(),
+			mavenBundle().groupId("org.daisy.dotify").artifactId("dotify.task.impl").versionAsInProject(),
 			brailleModule("common-utils"),
 			brailleModule("css-core"),
 			brailleModule("css-calabash"),
@@ -73,6 +96,12 @@ public class TranslationTest {
 			brailleModule("dotify-saxon"),
 			brailleModule("dotify-calabash"),
 			brailleModule("dotify-utils"),
+			brailleModule("pef-core"),
+			brailleModule("pef-calabash"),
+			brailleModule("pef-saxon"),
+			brailleModule("pef-utils"),
+			pipelineModule("common-utils"),
+			pipelineModule("file-utils"),
 			thisBundle(),
 			xprocspecBundles(),
 			junitBundles()

--- a/src/test/java/MTMTest.java
+++ b/src/test/java/MTMTest.java
@@ -86,6 +86,7 @@ public class MTMTest {
 			mavenBundle().groupId("org.daisy.dotify").artifactId("dotify.translator.impl").versionAsInProject(),
 			mavenBundle().groupId("org.daisy.dotify").artifactId("dotify.hyphenator.impl").versionAsInProject(),
 			mavenBundle().groupId("org.daisy.dotify").artifactId("dotify.formatter.impl").versionAsInProject(),
+			mavenBundle().groupId("org.daisy.dotify").artifactId("dotify.text.impl").versionAsInProject(),
 			mavenBundle().groupId("org.daisy.dotify").artifactId("dotify.task-api").versionAsInProject(),
 			mavenBundle().groupId("org.daisy.dotify").artifactId("dotify.task.impl").versionAsInProject(),
 			brailleModule("common-utils"),

--- a/src/test/xprocspec/test_script.xprocspec
+++ b/src/test/xprocspec/test_script.xprocspec
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description xmlns:x="http://www.daisy.org/ns/xprocspec"
+               xmlns:mtm="http://www.mtm.se/pipeline/"
+               script="../../main/resources/xml/dtbook-to-pef.xpl">
+  
+  <x:scenario label="dtbook-to-pef">
+    <x:call step="mtm:dtbook-to-pef">
+      <x:input port="source">
+        <x:document type="inline">
+          <dtbook xmlns="http://www.daisy.org/z3986/2005/dtbook/" xml:lang="sv">
+            <book>
+              <bodymatter>
+                <p>Testar modulen</p>
+              </bodymatter>
+            </book>
+          </dtbook>
+        </x:document>
+      </x:input>
+      <x:option name="output-dir" select="concat($temp-dir,'output-dir/')"/>
+    </x:call>
+    <x:context label="pef">
+      <x:document type="file" base-uri="temp-dir" href="output-dir/test_script.pef"/>
+    </x:context>
+    <x:expect label="pef" type="custom" href="http://www.daisy.org/pipeline/modules/braille/pef-utils/library.xpl" step="x:pef-compare">
+      <x:document type="inline">
+        <pef xmlns="http://www.daisy.org/ns/2008/pef" version="2008-1">
+          <head>
+            <meta>
+              <dc:format xmlns:dc="http://purl.org/dc/elements/1.1/">application/x-pef+xml</dc:format>
+            </meta>
+          </head>
+          <body>
+            <volume cols="40" rows="25" rowgap="0" duplex="false">
+              <section>
+                <page>
+                  <row>⠀</row>
+                  <row>⠀</row>
+                  <row>⠠⠞⠑⠎⠞⠁⠗⠀⠍⠕⠙⠥⠇⠑⠝</row>
+                  <row>⠀</row>
+                  <row>⠀</row>
+                </page>
+              </section>
+            </volume>
+          </body>
+        </pef>
+      </x:document>
+    </x:expect>
+  </x:scenario>
+  
+</x:description>

--- a/src/test/xprocspec/test_translator.xprocspec
+++ b/src/test/xprocspec/test_translator.xprocspec
@@ -31,9 +31,7 @@
     </x:context>
     <x:expect label="result" type="compare">
       <x:document type="inline">
-        <div xmlns="http://www.w3.org/1999/xhtml">
-          <p>⠋⠕⠕⠃⠁⠗</p>
-        </div>
+        <div xmlns="http://www.w3.org/1999/xhtml">⠀<p>⠋⠕⠕⠃⠁⠗</p>⠀</div>
       </x:document>
     </x:expect>
   </x:scenario>


### PR DESCRIPTION
Related: https://github.com/daisy/pipeline-mod-braille/pull/39
